### PR TITLE
Update Dash.workflow version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Python Package Index is very slow due to a lack on API and pagaination. A mi
 
 ![alt text][rpm]
 
-### Dash (1.2) [[Download](https://raw.github.com/willfarrell/alfred-workflows/master/Dash.alfredworkflow)]
+### Dash (1.3) [[Download](https://raw.github.com/willfarrell/alfred-workflows/master/Dash.alfredworkflow)]
 [Dash](http://kapeli.com/) comes with default Alfred 2 Workflow. This is an extension to that by shortening the keyword filters for each language. Does not require online connection.
 
 **Commands Included:** `dash {query}` (default), `html {query}`, `css {query}`, `js {query}`, `jquery {query}`, `angularjs {query}`, `bootstrap {query}`, `svg {query}`, `nodejs {query}`, `php {query}`, `redis {query}`, `mysql {query}`, `cpp {query}`, `backbone {query}`, `underscore {query}`, `sass {query}`, `compass {query}`, `wordpress {query}`, `drupal {query}`


### PR DESCRIPTION
Forgot to update version number in the Readme for Dash workflow, this fixes it.
