### PR TITLE
Fixed the encoding issues with characters like © and ®

### DIFF
--- a/encode-decode.json
+++ b/encode-decode.json
@@ -1,5 +1,5 @@
 {
-	"version": 1.1,
+	"version": 1.2,
 	"download_url": "https://raw.github.com/willfarrell/alfred-workflows/master/encode-decode.alfredworkflow",
     "description": "Encode/Decode Strings"
 }

--- a/encode-decode/encode.php
+++ b/encode-decode/encode.php
@@ -22,7 +22,7 @@ $utf8_encode = utf8_encode($query);
 if ($utf8_encode != $query) $encodes["UTF8 Encoded"] = $utf8_encode;
 
 // HTML
-$html_encode = htmlentities($query);
+$html_encode = htmlentities($query, ENT_QUOTES, 'UTF-8');
 if ($html_encode != $query) $encodes["HTML Encoded"] = $html_encode;
 //$dencodes["UTF-8 encoded"] = utf8_encode($query);
 


### PR DESCRIPTION
This fixes issue #24. By default php uses ISO-8859-1, we need to tell it to use UTF-8 to properly convert characters like © and ®
